### PR TITLE
Feature/field model performance

### DIFF
--- a/models/vss_field/model.sdf
+++ b/models/vss_field/model.sdf
@@ -13,7 +13,7 @@ https://bitbucket.org/osrf/gazebo/src/gazebo11/models/ground_plane/model.sdf -->
 <sdf version="1.5">
   <model name='vss_field'>
 
-    <static>1</static>
+    <static>true</static>
 
     <link name='base_link'>
       <pose frame=''>0 0 0 0 0 0</pose>
@@ -32,12 +32,11 @@ https://bitbucket.org/osrf/gazebo/src/gazebo11/models/ground_plane/model.sdf -->
       </inertial>
 
       <collision name='base_link_collision'>
-        <pose frame=''>0 0 0 0 0 0</pose>
+        <pose>0 0 -0.005 0 0 0</pose>
         <geometry>
-          <mesh>
-            <scale>1 1 1</scale>
-            <uri>model://vss_field/meshes/base_link.stl</uri>
-          </mesh>
+          <box>
+            <size>1.75 1.35 0.01</size>
+          </box>
         </geometry>
         <surface>
           <friction>

--- a/worlds/vss_field.world
+++ b/worlds/vss_field.world
@@ -26,7 +26,7 @@
 
     <!-- VSS ball -->
     <include>
-      <pose>0 0 0.032 0 0 0</pose>
+      <pose>0 0 0.0315 0 0 0</pose>
       <uri>model://vss_ball</uri>
     </include>
 

--- a/worlds/vss_field_spots.world
+++ b/worlds/vss_field_spots.world
@@ -26,7 +26,7 @@
 
     <!-- VSS ball -->
     <include>
-      <pose>0 0 0.032 0 0 0</pose>
+      <pose>0 0 0.0315 0 0 0</pose>
       <uri>model://vss_ball</uri>
     </include>
 


### PR DESCRIPTION
Fala galerinha, tava testando umas coisinhas aqui e reparei que fiz uma coisa não muito boa na PR de atualização do campo. Lá, eu mantive a colisão da base do campo como uma mesh, igual ao visual. Mas a gente não precisa disso, a colisão da nossa base pode ser aproximada por um bloco retangular sem nenhum problema, como é recomendado pelo gazebo.

Dessa forma, eu apenas troquei a mesh da colisão por um box. Reparem que a colisão agora passa um pouquinho pelo lado do campo, mas como eu disse, acho que não tem problema nenhum isso acontecer (em laranja é a colisão do modelo).

![image](https://user-images.githubusercontent.com/50970346/114632217-9727e880-9c94-11eb-9f95-6b3fa98ebf57.png)


## Motivação

Bom, eu só notei isso pq a gente tava tendo um errinho de aproximação no começo da simulação. Se vocês olharem a nossa mesh da base do campo, ela tem uma aresta que passa exatamente pelo (0, 0).

![image](https://user-images.githubusercontent.com/50970346/114632313-d7876680-9c94-11eb-9780-8714ba35eef2.png)

Quando a gente spawnava a bola no mundo, ela calculava a colisão exatamente no (0,0), e acabava rolando um pouquinho, já que ela não sabe direito o que fazer ali naquele ponto. (esperem um pouquinho pq demora pra começar a rolar de fato).

![field_bug](https://user-images.githubusercontent.com/50970346/114632564-57153580-9c95-11eb-8558-753fc6cef202.gif)

Isso foi resolvido apenas spawnando a bola 5mm mais baixo, só com isso ele ja parou de dar esse erro. Mas, para evitar esses errinhos nas outras partes da mesh, preferi trocar a colisão pelo box. Agora ele funciona bonitinho spawnando de qualquer altura.

![field_fixed_2](https://user-images.githubusercontent.com/50970346/114632789-c559f800-9c95-11eb-946a-5d2455f2c0f7.gif)

---

Bom, é isso, no final das contas também mudei a altura da bola só pra ficar mais pertinho do campo e ela não ficar kickando tanto.