### PR TITLE
🔧 FIx diff drive controller parameters

### DIFF
--- a/config/motor_diff_drive.yml
+++ b/config/motor_diff_drive.yml
@@ -10,11 +10,9 @@ diff_drive_controller:
   left_wheel: roda_esq_joint
   right_wheel: roda_dir_joint
 
-  wheel_separation: 0.07 # meters
-  wheel_separation_multiplier: 0.88
+  wheel_separation: 0.071 # meters
 
   wheel_radius: 0.025 # meters
-  wheel_radius_multiplier: 0.715
 
   # Odometry covariances for the encoder output of the robot. These values should
   # be tuned to your robot's sample odometry data, but these values are a good place


### PR DESCRIPTION
Opa pessoal, 
Essa PR tem como intuito arrumar as constantes de "wheel_separation" e remover os "multipliers" do arquivo "config/motor_diff_drive.yml", que causaram certo ruído nos testes da #32 ontem. Com a orientação do @lucastrschneider , testei alguns valores para a separação entre as rodas para ver qual causava menos ruído. Os valores testados para "wheel_separation" foram: 0.055 (distância entre as partes internas da roda), 0.063 (distância entre os centros das rodas) e 0.071 (distância entre as partes externas das rodas).

Nos testes, o tópico do comando de velocidade recebeu a seguinte velocidade angular: sin(i/30) * 6 (i = tempo em segundos).

Indo para os resultados:
### **Ontem (só calibrando o PID, ainda com os multipliers)**
![antes](https://user-images.githubusercontent.com/62343088/115428629-f5932080-a1d8-11eb-8edb-1abcb52eb047.png)

### **Sem os multipliers:**
### **wheel_separaion = 0.055**
![0,55](https://user-images.githubusercontent.com/62343088/115429635-f7a9af00-a1d9-11eb-82a2-35ba9f6695ce.png)

### **wheel_separaion = 0.063**
![0,63](https://user-images.githubusercontent.com/62343088/115429956-4d7e5700-a1da-11eb-91f5-4fb6d174b1ad.png)

### **wheel_separaion = 0.071**
![Screenshot from 2021-04-20 12-16-27](https://user-images.githubusercontent.com/62343088/115430081-6e46ac80-a1da-11eb-8ebb-918c8e42b551.png)

Deu pra ver que o ruído diminui bastante, especialmente para wheel_separaion = 0.071. Nesse caso, foram feitos testes adicionais variando a frequência e amplitude. Algumas situações tiveram um pouco mais de ruído, mas ainda menor do que nos outros valores de wheel_separation.
