### PR TITLE
Add archive notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+🚨 **This project has been archived! Check its newer version [here](https://github.com/futebol-mini/travesim)** 🚨
+
+---
+
 <h1 align="center">🥅 TraveSim</h1>
 <p align="center">IEEE Very Small Size Soccer simulation project with ROS and Gazebo</p>
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -1,3 +1,7 @@
+🚨 **Esse projeto foi arquivado! Confira a nova versão [aqui](https://github.com/futebol-mini/travesim)** 🚨
+
+---
+
 <h1 align="center">🥅 TraveSim</h1>
 <p align="center">Projeto de simulação de um time IEEE VSS em um campo oficial em ROS utilizando Gazebo</p>
 
@@ -40,7 +44,6 @@
   <img height=200px src="./docs/screenshot_match.png" />
   <img height=200px src="./docs/screenshot_match_5x5.png" />
 </p>
-
 
 ## 🎈 Introdução
 


### PR DESCRIPTION
Com a decisão de migrar para webots e continuar o desenvolvimento na junto à organização da liga [no repo novo](https://github.com/futebol-mini/travesim), esse repo deve ser arquivado

Essa PR adiciona o aviso de arquivamento, junto de um link para o repo novo